### PR TITLE
Fix security hole ... do *NOT* open the app port on the outside if the port is only meant for internal reverse-proxy use !

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -49,12 +49,11 @@ ynh_app_setting_set --app=$app --key=path --value=$path_url
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_script_progression --message="Configuring firewall..." --weight=1
+ynh_script_progression --message="Finding an available port..." --weight=1
 
 # Find a free port
 port=$(ynh_find_port --port=1880)
 # Open this port
-ynh_exec_warn_less yunohost firewall allow --no-upnp TCP $port
 ynh_app_setting_set --app=$app --key=port --value=$port
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -53,7 +53,6 @@ ynh_script_progression --message="Finding an available port..." --weight=1
 
 # Find a free port
 port=$(ynh_find_port --port=1880)
-# Open this port
 ynh_app_setting_set --app=$app --key=port --value=$port
 
 #=================================================
@@ -87,8 +86,8 @@ ynh_script_progression --message="Installing Node-RED..." --weight=2
 chown -R $app: $final_path
 
 pushd $final_path
-ynh_use_nodejs
-exec_as $app env PATH=$PATH npm install --production
+	ynh_use_nodejs
+	exec_as $app env PATH=$PATH npm install --production
 popd
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -81,11 +81,6 @@ fi
 # REMOVE THE LOG FILE
 #=================================================
 
-# Remove from npm
-# If multiple instances, it will break the others
-# Need a way to count
-#npm uninstall node-red -g
-
 # Remove the log files
 ynh_secure_remove --file="/var/log/$app/"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -105,8 +105,8 @@ ynh_script_progression --message="Installing Node-RED..." --weight=30
 chown -R $app: $final_path
 
 pushd $final_path
-ynh_use_nodejs
-exec_as $app env PATH=$PATH npm install --production
+	ynh_use_nodejs
+	exec_as $app env PATH=$PATH npm install --production
 popd
 
 #=================================================
@@ -121,7 +121,7 @@ ynh_add_nginx_config
 # SPECIFIC UPGRADE
 #=================================================
 if [ ! -f $final_path/data/settings.js ]; then
-    cp $final_path/settings.js $final_path/data/settings.js
+	cp $final_path/settings.js $final_path/data/settings.js
 fi
 ynh_replace_string --match_string="//httpRoot: '/red'," --replace_string="httpRoot: '$path_url'," --target_file="$final_path/data/settings.js"
 ynh_replace_string --match_string="//ui: { path: "ui" }," --replace_string="ui: { path: "/ui/" }," --target_file="$final_path/data/settings.js"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -62,6 +62,19 @@ ynh_clean_setup () {
 # Exit if an error occurs during the execution of the script
 ynh_abort_if_errors
 
+
+#=================================================
+# CLOSING PORT
+#=================================================
+
+# In older versions of the package, the port serving the webui was opened to anyone,
+# allowing direct access to Node-RED... let's close it.
+if yunohost firewall list | grep -q "\- $port$"
+then
+        ynh_script_progression --message="Closing port $port..."
+        ynh_exec_warn_less yunohost firewall disallow TCP $port
+fi
+
 #=================================================
 # STANDARD UPGRADE STEPS
 #=================================================


### PR DESCRIPTION
NB : I haven't checked to be 100% sure it's not needed, feel free to close and ignore if this PR is not relevant. I'm just trying to through all the possible apps with this issue ...

Otherwise : 
- this should be fixed ASAP >_>
- I haven't checked other scripts (upgrade, restore, ..?) which may also have this line in where this should be removed
- To properly fix the issue for existing installs, the remove script should be adapted to close that port if it's opened...
