### PR TITLE
Tune systemd restrictions to allow USB and network communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ You can check the default settings Yunohost generates at `/opt/yunohost/nodered/
 **Shipped version:** 3.0.2~ynh2
 
 
-
 ## Screenshots
 
 ![Screenshot of Node-RED](./doc/screenshots/screenshot.jpg)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ logging: { // replace the default logging option ...defaultSettings.logging, // 
 You can check the default settings Yunohost generates at `/opt/yunohost/nodered/data/settings.js` and find the documentation for configuring Node-RED here: https://nodered.org/docs/user-guide/runtime/configuration
 
 
-**Shipped version:** 3.0.2~ynh1
+**Shipped version:** 3.0.2~ynh2
+
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -49,7 +49,8 @@ module.exports = (defaultSettings) => ({
 Vous pouvez consulter les paramètres par défaut générez par Yunohost dans `/opt/yunohost/nodered/data/settings.js` et trouver la documentation pour configurer Node-RED ici: https://nodered.org/docs/user-guide/runtime/configuration
 
 
-**Version incluse :** 3.0.2~ynh1
+**Version incluse :** 3.0.2~ynh2
+
 
 ## Captures d'écran
 

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -18,7 +18,8 @@ StandardError=inherit
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
 NoNewPrivileges=yes
 PrivateTmp=yes
-PrivateDevices=yes
+# Remove to allow the app to talk to USB devices
+#PrivateDevices=yes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 RestrictNamespaces=yes
 RestrictRealtime=yes
@@ -28,7 +29,8 @@ ProtectControlGroups=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes
 LockPersonality=yes
-SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+# @setuid removed from the list because it is needed by some network utilities (ping)
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @swap
 
 # Denying access to capabilities that should not be relevant for webapps
 # Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Flow-based programming for the Internet of Things",
         "fr": "Programmation par flux de données pour l'Internet des objets"
     },
-    "version": "3.0.2~ynh1",
+    "version": "3.0.2~ynh2",
     "url": "https://nodered.org",
     "upstream": {
         "license": "Apache-2.0",


### PR DESCRIPTION
## Problem

cf. https://forum.yunohost.org/t/node-red-probleme-de-permission-et-dipv6/21071/4

User cannot use nodes related to USB communication and `ping` command.

## Solution

- Lift some systemd restrictions

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
