### PR TITLE
Fix palette catalog not loading

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,7 +12,7 @@ location ^~ __PATH__/ {
   proxy_set_header Connection "Upgrade";
 
   # Enable websockets (see: https://github.com/YunoHost-Apps/nodered_ynh/issues/78 )
-  more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; connect-src 'self' wss://$host; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'; worker-src 'self' blob:;";
+    more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; connect-src 'self' wss://$host https://catalogue.nodered.org/; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'; worker-src 'self' blob:;";
 
   # Include SSOWAT user panel.
   include conf.d/yunohost_panel.conf.inc;


### PR DESCRIPTION
Adding https://catalogue.nodered.org/ to connect-src allowed  hosts

## Problem

When trying to install package from interface, xhr to `catalogue.nodered.org` is blocked due to _connect-src_ rule

## Solution

We should allow `https://catalogue.nodered.org/` in _connect-src_, elsewhere browser will catalog listing and people will be unable to install packages from NodeRed interface

This PR complete the follow change : https://github.com/YunoHost-Apps/nodered_ynh/commit/456a26be3800004358fcc64f3f84d367350c9e38

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)
