### PR TITLE
Update Node.js version from 20 to 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Flow-based programming for the Internet of Things
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://nodered.org)
-[![Version: 4.1.10~ynh1](https://img.shields.io/badge/Version-4.1.10~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/nodered/)
+[![Version: 4.1.10~ynh2](https://img.shields.io/badge/Version-4.1.10~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/nodered/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/nodered"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -73,4 +73,4 @@ ram.runtime = "70M"
     main.default = 1880
 
     [resources.nodejs]
-    version = "20"
+    version = "22"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Node-RED"
 description.en = "Flow-based programming for the Internet of Things"
 description.fr = "Programmation par flux de données pour l'Internet des objets"
 
-version = "4.1.10~ynh1"
+version = "4.1.10~ynh2"
 
 maintainers = ["tituspijean"]
 


### PR DESCRIPTION
## Problem

- Some modules requires Node in version 22 (which is LTS). For example: node-red-contrib-matrix-chat

## Solution

- Update the node requirement

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
